### PR TITLE
Update build_and_release_charts version to avoid token error

### DIFF
--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -2,7 +2,7 @@ name: Build and Publish Helm charts
 on: [push, pull_request, workflow_dispatch]
 jobs:
   build_and_release:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v3
     with:
       artifactory-component: telemetry-metrics-filter
       target-branch: main


### PR DESCRIPTION
This PR updates the version of the `hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml` workflow to `v3`, to avoid token errors when trying to publish charts.

I hit this problem in a PR in the hms-smd-charts repo and eventually found the solution here:
https://cray.slack.com/archives/C01JRKK8J2F/p1716411647280019?thread_ts=1716410735.218279&cid=C01JRKK8J2F

This PR has no content otherwise -- it is just so the next person who makes a PR to this repo doesn't need to figure out why that step is failing for their PR.

I had to make this PR from a fork as I lack developer access to the repo